### PR TITLE
2122: fixed crash caused by indexing with the wrong variable

### DIFF
--- a/babelsubs/storage.py
+++ b/babelsubs/storage.py
@@ -151,7 +151,9 @@ class _Differ(object):
             return
         items1 = set_1.subtitle_items(mappings)
         items2 = set_2.subtitle_items(mappings)
-
+        # We calculate text_changed/time_changed by using
+        # SequenceMatcher.ratio() method that targets the text/time data
+        # specifically.
         text_changed = self.calc_changed_amout([s.text for s in items1],
                                                [s.text for s in items2])
         time_changed = self.calc_changed_amout(
@@ -170,6 +172,8 @@ class _Differ(object):
         return 1.0 - sm.ratio()
 
     def calc_subtitle_data(self, items1, items2):
+        # when calculating the diff, we only match against the times/text and
+        # ignore the meta.
         sm = difflib.SequenceMatcher(
             None,
             [(i.start_time, i.end_time, i.text) for i in items1],
@@ -185,7 +189,7 @@ class _Differ(object):
                     if i is None:
                         self.make_subtitle_data_item(empty_line, items2[j])
                     elif j is None:
-                        self.make_subtitle_data_item(items1[j], empty_line)
+                        self.make_subtitle_data_item(items1[i], empty_line)
                     else:
                         self.make_subtitle_data_item(items1[i], items2[j])
 

--- a/babelsubs/tests/test_diffing.py
+++ b/babelsubs/tests/test_diffing.py
@@ -10,6 +10,9 @@ class DiffingTest(TestCase):
         self.assertEqual(len(result['subtitle_data']), 0)
 
 
+    def empty_line(self):
+        return SubtitleLine(None, None, None, None)
+
     def test_one_set_empty(self):
         set_1 = SubtitleSet.from_list('en', [
             (0, 1000, "Hey 1"),
@@ -67,6 +70,14 @@ class DiffingTest(TestCase):
             self.assertEqual(sub_data['time_changed'], i ==1)
             self.assertFalse(sub_data['text_changed'])
 
+    def check_unchanged_subtitle_data(self, result, set_1, set_2, *indexes):
+        for i in indexes:
+            sub_data = result['subtitle_data'][i]
+            self.assertEquals(sub_data['time_changed'], False)
+            self.assertEquals(sub_data['text_changed'], False)
+            self.assertEquals(sub_data['subtitles'][0],
+                              sub_data['subtitles'][1])
+
     def test_insert(self):
         set_1 = SubtitleSet.from_list('en', [
          (0, 1000, "Hey 1"),
@@ -84,26 +95,153 @@ class DiffingTest(TestCase):
         result = diff(set_1, set_2)
         self.assertEqual(result['changed'], True)
         # for both time_change and text_changed, we calculate them as follows:
-        # there are 9 total subs (4 in set_1, 5 in set_2).  8 of those are
-        # matches and 1 is new in set_2.  So the change amount is 1/9
+        # there are 9 total subs.  8 of those are matches and 1 is new in
+        # set_2.  So the change amount is 1/9
         self.assertAlmostEqual(result['time_changed'], 1/9.0)
         self.assertAlmostEqual(result['text_changed'], 1/9.0)
         self.assertEqual(len(result['subtitle_data']), 5)
 
         # check the lines that haven't changed
-        for i in (0, 2, 3, 4):
-            sub_data = result['subtitle_data'][i]
-            self.assertEquals(sub_data['time_changed'], False)
-            self.assertEquals(sub_data['text_changed'], False)
-            self.assertEquals(sub_data['subtitles'][0], set_2[i])
-            self.assertEquals(sub_data['subtitles'][1], set_2[i])
+        self.check_unchanged_subtitle_data(result, set_1, set_2, 0, 2, 3, 4)
         # check the line that was inserted
         insert_sub_data = result['subtitle_data'][1]
         self.assertEquals(insert_sub_data['time_changed'], True)
         self.assertEquals(insert_sub_data['text_changed'], True)
-        self.assertEquals(insert_sub_data['subtitles'][0],
-                          SubtitleLine(None, None, None, None))
+        self.assertEquals(insert_sub_data['subtitles'][0], self.empty_line())
         self.assertEquals(insert_sub_data['subtitles'][1], set_2[1])
+
+    def test_delete(self):
+        set_1 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 2000, "Hey 2"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        set_2 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        result = diff(set_1, set_2)
+        self.assertEqual(result['changed'], True)
+        # for both time_change and text_changed, we calculate them as follows:
+        # there are 7 total subs.  6 of those are matches and 1 is new in
+        # set_2.  So the change amount is 1/9
+        self.assertAlmostEqual(result['time_changed'], 1/7.0)
+        self.assertAlmostEqual(result['text_changed'], 1/7.0)
+        self.assertEqual(len(result['subtitle_data']), 4)
+
+        # check the lines that haven't changed
+        self.check_unchanged_subtitle_data(result, set_1, set_2, 0, 2, 3)
+        # check the line that was deleted
+        delete_sub_data = result['subtitle_data'][1]
+        self.assertEquals(delete_sub_data['time_changed'], True)
+        self.assertEquals(delete_sub_data['text_changed'], True)
+        self.assertEquals(delete_sub_data['subtitles'][1], self.empty_line())
+        self.assertEquals(delete_sub_data['subtitles'][0], set_1[1])
+
+    def test_simple_replace(self):
+        set_1 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 2000, "Hey 2"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        set_2 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 2000, "Hey New 2"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        result = diff(set_1, set_2)
+        self.assertEqual(result['changed'], True)
+        self.assertAlmostEqual(result['time_changed'], 0)
+        # for text_changed, we calculate as follows: there are 8 total subs.
+        # 6 of those are matches and 1 is different in both sets.  So 2/8.0
+        # has been changed.
+        self.assertAlmostEqual(result['text_changed'], 2/8.0)
+        self.assertEqual(len(result['subtitle_data']), 4)
+
+        # check the lines that haven't changed
+        self.check_unchanged_subtitle_data(result, set_1, set_2, 0, 2, 3)
+        # check the line that was inserted
+        insert_sub_data = result['subtitle_data'][1]
+        self.assertEquals(insert_sub_data['time_changed'], False)
+        self.assertEquals(insert_sub_data['text_changed'], True)
+        self.assertEquals(insert_sub_data['subtitles'][0], set_1[1])
+        self.assertEquals(insert_sub_data['subtitles'][1], set_2[1])
+
+    def test_replace_single_line_with_multiple(self):
+        set_1 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 2000, "Hey 2"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        set_2 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 1500, "Hey 2.1"),
+         (1500, 2000, "Hey 2.2"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        result = diff(set_1, set_2)
+        self.assertEqual(result['changed'], True)
+        # for both time_change and text_changed, we calculate them as follows:
+        # there are 9 total subs.  6 of those are matches and 1 in set 1 was
+        # changed to 2 in set 2.  So the change amount is 3/9.
+        self.assertAlmostEqual(result['time_changed'], 3/9.0)
+        self.assertAlmostEqual(result['text_changed'], 3/9.0)
+        self.assertEqual(len(result['subtitle_data']), 5)
+
+        # check the lines that haven't changed
+        self.check_unchanged_subtitle_data(result, set_1, set_2, 0, 3, 4)
+        # line 1 in set_1 was replaced my lines 2 and 3 in set_2
+        line1 = result['subtitle_data'][1]
+        self.assertEquals(line1['time_changed'], True)
+        self.assertEquals(line1['text_changed'], True)
+        self.assertEquals(line1['subtitles'][0], set_1[1])
+        self.assertEquals(line1['subtitles'][1], set_2[1])
+        line2 = result['subtitle_data'][2]
+        self.assertEquals(line2['time_changed'], True)
+        self.assertEquals(line2['text_changed'], True)
+        self.assertEquals(line2['subtitles'][0], self.empty_line())
+        self.assertEquals(line2['subtitles'][1], set_2[2])
+
+    def test_replace_multiple_lines_with_single(self):
+        set_1 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 2000, "Hey 2"),
+         (2000, 3000, "Hey 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        set_2 = SubtitleSet.from_list('en', [
+         (0, 1000, "Hey 1"),
+         (1000, 3000, "Hey 2 and 3"),
+         (3000, 4000, "Hey 4"),
+        ])
+        result = diff(set_1, set_2)
+        self.assertEqual(result['changed'], True)
+        # for both time_change and text_changed, we calculate them as follows:
+        # there are 7 total subs.  4 of those are matches and 2 in set_1 were
+        # replaced with 1 in set_2.  So the change amount is 3/7.
+        self.assertAlmostEqual(result['time_changed'], 3/7.0)
+        self.assertAlmostEqual(result['text_changed'], 3/7.0)
+        self.assertEqual(len(result['subtitle_data']), 4)
+
+        # check the lines that haven't changed
+        self.check_unchanged_subtitle_data(result, set_1, set_2, 0, 3)
+        # check the line that was inserted
+        line1 = result['subtitle_data'][1]
+        self.assertEquals(line1['time_changed'], True)
+        self.assertEquals(line1['text_changed'], True)
+        self.assertEquals(line1['subtitles'][0], set_1[1])
+        self.assertEquals(line1['subtitles'][1], set_2[1])
+        line2 = result['subtitle_data'][2]
+        self.assertEquals(line2['time_changed'], True)
+        self.assertEquals(line2['text_changed'], True)
+        self.assertEquals(line2['subtitles'][0], set_1[2])
+        self.assertEquals(line2['subtitles'][1], self.empty_line())
 
     def test_data_ordering(self):
         set_1 = SubtitleSet.from_list('en', [


### PR DESCRIPTION
Added a bunch of unittests, I think we cover all the cases of diffing
now.  Added a couple comments to the diffing code.
