### PR TITLE
Adding support to WebVTT (.vtt) to babelsubs.

### DIFF
--- a/babelsubs/generators/__init__.py
+++ b/babelsubs/generators/__init__.py
@@ -7,3 +7,4 @@ from ssa import SSAGenerator
 from txt import TXTGenerator
 from html import HTMLGenerator
 from json_generator import JSONGenerator
+from webvtt import WEBVTTGenerator

--- a/babelsubs/generators/webvtt.py
+++ b/babelsubs/generators/webvtt.py
@@ -1,0 +1,39 @@
+from babelsubs.generators.base import BaseGenerator, register
+from babelsubs.utils import UNSYNCED_TIME_FULL
+
+
+class WEBVTTGenerator(BaseGenerator):
+    file_type = 'vtt'
+
+    MAPPINGS = dict(linebreaks="\n", bold="<b>%s</b>",
+                    italics="<i>%s</i>", underline="<u>%s</u>")
+
+    def __init__(self, subtitle_set, language=None):
+        super(WEBVTTGenerator, self).__init__(subtitle_set, language)
+        self.line_delimiter = '\r\n'
+
+    def __unicode__(self):
+        output = ['WEBVTT\n']
+        i = 1
+        for from_ms, to_ms, content, meta in self.subtitle_set.subtitle_items(mappings=self.MAPPINGS):
+            output.append(unicode(i))
+            output.append(u'%s --> %s' % (
+                self.format_time(from_ms),
+                self.format_time(to_ms)
+            ))
+            output.append(content)
+            output.append(u'')
+            i += 1
+        return self.line_delimiter.join(output)[:-1]
+
+    def format_time(self, milliseconds):
+        if milliseconds is None:
+            milliseconds = UNSYNCED_TIME_FULL
+
+        seconds, milliseconds = divmod(int(milliseconds), 1000)
+        minutes, seconds = divmod(seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        return u"%02i:%02i:%02i.%03i" % (hours, minutes, seconds, milliseconds)
+
+
+register(WEBVTTGenerator)

--- a/babelsubs/parsers/__init__.py
+++ b/babelsubs/parsers/__init__.py
@@ -7,3 +7,4 @@ from ssa import SSAParser
 from txt import TXTParser
 from json_parser import JSONParser
 from youtube import YoutubeParser
+from webvtt import WEBVTTParser

--- a/babelsubs/parsers/webvtt.py
+++ b/babelsubs/parsers/webvtt.py
@@ -1,0 +1,74 @@
+import re
+
+from lxml import etree
+from babelsubs import utils
+from babelsubs.parsers.base import BaseTextParser, register
+
+class WEBVTTParser(BaseTextParser):
+
+    file_type = 'vtt'
+    _clean_pattern = re.compile(r'\{.*?\}', re.DOTALL)
+
+    def __init__(self, input_string, language_code, eager_parse=True):
+        pattern = r'\d+\s*?\n'
+        pattern += r'(?P<s_hour>\d{2}):(?P<s_min>\d{2}):(?P<s_sec>\d{2})(.(?P<s_secfr>\d*))?'
+        pattern += r' --> '
+        pattern += r'(?P<e_hour>\d{2}):(?P<e_min>\d{2}):(?P<e_sec>\d{2})(.(?P<e_secfr>\d*))?'
+        pattern += r'\n(\n|(?P<text>.+?)\n\n)'
+        input_string = input_string.replace('\r\n', '\n').replace('\r', '\n')+'\n\n'
+        super(WEBVTTParser, self).__init__(input_string, pattern, language=language_code,
+            flags=[re.DOTALL], eager_parse=eager_parse)
+
+
+    def _get_time(self, hour, min, sec, milliseconds):
+        if milliseconds is None:
+            milliseconds = '0'
+        res  =  (int(hour)*60*60+int(min)*60+int(sec)+float('.'+milliseconds)) * 1000
+        if res == utils.UNSYNCED_TIME_FULL:
+            res = None
+        return res
+
+    def _get_data(self, match):
+        output = {}
+        output['start'] = self._get_time(match['s_hour'],
+                                         match['s_min'],
+                                         match['s_sec'],
+                                         match['s_secfr'])
+        output['end'] = self._get_time(match['e_hour'],
+                                       match['e_min'],
+                                       match['e_sec'],
+                                       match['e_secfr'])
+        output['text'] = (
+            '' if match['text'] is None else
+            utils.escape_ampersands(utils.strip_tags(
+                self._clean_pattern.sub('', match['text'])))
+        )
+        return output
+
+    def get_markup(self, text):
+        # create a simple element so we can parse using etree
+        # webvtt uses html like tags as markup
+        base = "<p>%s</p>" % text
+        el = etree.fromstring(base)
+
+        content = [el.text]
+        base_span = '<span %s>%s</span>'
+
+        for child in el.getchildren():
+            tag = child.tag
+
+            if tag == 'b':
+                content.append(base_span % ('fontWeight="bold"', child.text))
+            elif tag == 'i':
+                content.append(base_span % ('fontStyle="italic"', child.text))
+            elif tag == 'u':
+                content.append(base_span % ('textDecoration="underline"', child.text))
+
+            content.append(child.tail)
+
+        if el.tail:
+            content.append(el.tail.strip())
+
+        return "".join(filter(None, content)).replace("\n", "<br />")
+
+register(WEBVTTParser)

--- a/babelsubs/tests/data/Untimed_text.vtt
+++ b/babelsubs/tests/data/Untimed_text.vtt
@@ -1,0 +1,205 @@
+1
+99:59:59.000 --> 99:59:59.000
+Comfortably get back into the rhythm again, 
+heart rate was peaking up at 170.
+
+2
+99:59:59.000 --> 99:59:59.000
+I'm gutted. 
+Absolutely gutted.
+
+3
+99:59:59.000 --> 99:59:59.000
+Got it back in my legs to get 
+to the top but, snow's in the way.
+
+4
+99:59:59.000 --> 99:59:59.000
+Just want to go and have a look. 
+Just round that corner and if there's tarmac...
+
+5
+99:59:59.000 --> 99:59:59.000
+This is nuts! Just that corner there, 
+I carry the bike through to there and I'm off.
+
+6
+99:59:59.000 --> 99:59:59.000
+What?
+No, I need to get up round here. Anyone?
+
+7
+99:59:59.000 --> 99:59:59.000
+12 metres high mate, 
+we've gotta go back.
+
+8
+99:59:59.000 --> 99:59:59.000
+What the snow?  
+Yeah. We cant go on.
+
+9
+99:59:59.000 --> 99:59:59.000
+He's saying you could die mate, 
+we've gotta go.
+
+10
+99:59:59.000 --> 99:59:59.000
+Thank you.
+Thank you.
+
+11
+99:59:59.000 --> 99:59:59.000
+Yesterday, after we got snowed out 
+of Madeleine, ah, I was absolutely gutted.
+
+12
+99:59:59.000 --> 99:59:59.000
+My legs would've got me up there, 
+but Madeleine said no.
+
+13
+99:59:59.000 --> 99:59:59.000
+I had a bit of a brief this morning, 
+as to what's to come...
+
+14
+99:59:59.000 --> 99:59:59.000
+So today we've got another legendary 
+Tour de France climb for you to take on,
+
+15
+99:59:59.000 --> 99:59:59.000
+the Col de la Croix de Fer 
+which is the "Call of the Iron Cross".
+
+16
+99:59:59.000 --> 99:59:59.000
+It was first used in the tour in 1947.
+
+17
+99:59:59.000 --> 99:59:59.000
+So they've been coming up 
+here for over 50 years.
+
+18
+99:59:59.000 --> 99:59:59.000
+The last 5 or 6k's from what I hear 
+is gonna smash my legs to pieces.
+
+19
+99:59:59.000 --> 99:59:59.000
+I'm gunning for this one. 
+I need this one in the bag.
+
+20
+99:59:59.000 --> 99:59:59.000
+[Music]
+
+21
+99:59:59.000 --> 99:59:59.000
+There you go buddy.  
+Thank you.
+
+22
+99:59:59.000 --> 99:59:59.000
+[Music plays again]
+
+23
+99:59:59.000 --> 99:59:59.000
+Just find a good rhythm.
+Yeah.
+
+24
+99:59:59.000 --> 99:59:59.000
+Find a good rhythm, tap it out.
+Feel the rhythm! Feel the rhythm!
+
+25
+99:59:59.000 --> 99:59:59.000
+[laughs]
+
+26
+99:59:59.000 --> 99:59:59.000
+Ahh, I've got no pacing left.
+
+27
+99:59:59.000 --> 99:59:59.000
+You can do it. 
+Dig, dig, dig, dig!
+
+28
+99:59:59.000 --> 99:59:59.000
+Oh (breathes heavily).
+
+29
+99:59:59.000 --> 99:59:59.000
+This is not your lungs, 
+it's your legs just exploding.
+
+30
+99:59:59.000 --> 99:59:59.000
+We're coming into cloud land now. 
+[Puffing] Oh! My ears popped. Jeez.
+
+31
+99:59:59.000 --> 99:59:59.000
+You get the impression 
+they do not want you at the top.
+
+32
+99:59:59.000 --> 99:59:59.000
+[radio static]
+...you're about 100 metres away.
+
+33
+99:59:59.000 --> 99:59:59.000
+Oh, hands are like ice blocks! 
+Feet, can't even feel my toes. Oh.
+
+34
+99:59:59.000 --> 99:59:59.000
+Oh my legs! 
+Can't even hold a straight line.
+
+35
+99:59:59.000 --> 99:59:59.000
+It's such a long day out, 
+but, this, don't even know now,
+
+36
+99:59:59.000 --> 99:59:59.000
+how much further you've got to go 
+'cos you can't see in front of you.
+
+37
+99:59:59.000 --> 99:59:59.000
+[Applause and cheering]
+
+38
+99:59:59.000 --> 99:59:59.000
+We're getting there are we there? 
+Are we there?
+
+39
+99:59:59.000 --> 99:59:59.000
+[Car beeps horn]
+
+40
+99:59:59.000 --> 99:59:59.000
+Yes!
+
+41
+99:59:59.000 --> 99:59:59.000
+[Cheering continues]
+
+42
+99:59:59.000 --> 99:59:59.000
+Yeah! How's that!
+
+43
+99:59:59.000 --> 99:59:59.000
+Ollie! Ollie! Ollie! Let three line ends here
+
+
+

--- a/babelsubs/tests/data/basic.vtt
+++ b/babelsubs/tests/data/basic.vtt
@@ -1,0 +1,76 @@
+1
+00:00:01.000 --> 00:00:03.000
+WebVTT combined with HTML5 brings accessability to the web
+
+2
+00:00:03.320 --> 00:00:06.000
+because we believe that every video on the web should be subtitle-able.
+
+3
+00:00:06.500 --> 00:00:11.100
+Millions of Deaf and hard-of-hearing viewers require subtitles to access video.
+
+4
+00:00:11.050 --> 00:00:15.025
+Videomakers and websites should <i>really</i> care about this stuff too.
+
+5
+00:00:15.025 --> 00:00:20.076
+Subtitles give them access to a <u>wider audience</u> and they also get better search rankings.
+
+6
+00:00:20.076 --> 00:00:27.026
+Universal Subtitles makes it incredibly easy to add subtitles to almost any video.
+
+7
+00:00:27.026 --> 00:00:32.033
+Take an existing video on the web, submit the <b>URL<br/></b> to our website
+
+8
+00:00:32.033 --> 00:00:39.003
+and then type along with the dialog
+to create the subtitles
+
+9
+00:00:39.003 --> 00:00:44.049
+After that, tap on your keyboard to sync them with the video.
+
+10
+00:00:44.049 --> 00:00:47.041
+Then you're done— we give you an embed code for the video
+
+11
+00:00:47.041 --> 00:00:49.076
+that you can put on any website
+
+12
+00:00:49.076 --> 00:00:53.045
+at that point, viewers are able to use the subtitles and can also
+
+13
+00:00:53.045 --> 00:00:55.083
+contribute to translations.
+
+14
+00:00:55.083 --> 00:01:01.041
+We support videos on YouTube, Blip.TV, Ustream, and many more.
+
+15
+00:01:01.041 --> 00:01:05.023
+Plus we're adding more services all the time
+
+16
+00:01:05.023 --> 00:01:08.068
+Universal Subtitles works with many popular video formats,
+
+17
+00:01:08.068 --> 00:01:13.079
+such as MP4, theora, webM and <i>&</i> HTML 5.
+
+18
+00:01:13.079 --> 00:01:19.041
+Our goal is for every video on the web to be subtitle-able so that anyone who cares about \<script\>alert\<script\>
+
+19
+00:01:19.041 --> 00:01:22.066
+the video can help make it more accessible.<script>alert</script>

--- a/babelsubs/tests/data/timed_text.vtt
+++ b/babelsubs/tests/data/timed_text.vtt
@@ -1,0 +1,20 @@
+1
+00:00:00.028 --> 00:00:01.061
+<i>[narrator] Once upon a time,</i>
+
+2
+00:00:02.008 --> 00:00:04.099
+<i>in an office building far, far, away,</i>
+
+3
+00:00:05.054 --> 00:00:09.048
+<i>a seemingly insignificant business meeting was called...</i>
+
+4
+00:00:10.047 --> 00:00:12.035
+- <i>[Boss]  I'm very glad you 
+all have gathered here.</i>
+
+5
+00:00:12.048 --> 00:00:13.015
+- If I may ask...

--- a/babelsubs/tests/test_webvtt.py
+++ b/babelsubs/tests/test_webvtt.py
@@ -1,0 +1,87 @@
+from unittest2 import TestCase
+
+from lxml import etree
+from babelsubs.storage import get_contents, SubtitleSet, TTS_NAMESPACE_URI
+from babelsubs.generators.webvtt import WEBVTTGenerator
+from babelsubs.parsers import SubtitleParserError
+from babelsubs.parsers.webvtt	 import WEBVTTParser
+from babelsubs.tests import utils
+
+import babelsubs
+
+class WEBVTTParsingTest(TestCase):
+
+    def test_basic(self):
+        subs  = utils.get_subs("basic.vtt")
+        self.assertEquals(len(subs), 19)
+
+    def setUp(self):
+        self.dfxp = utils.get_subs("with-formatting.dfxp").to_internal()
+        self.subs = self.dfxp.subtitle_items(mappings=WEBVTTGenerator.MAPPINGS)
+
+    def test_generated_formatting(self):
+        self.assertEqual(self.subs[2].text,'It has <b>bold</b> formatting' )
+        self.assertEqual(self.subs[3].text,'It has <i>italics</i> too' )
+        self.assertEqual(self.subs[4].text,'And why not <u>underline</u>' )
+        self.assertEqual(self.subs[5].text,'It has a html tag <a> should be in brackets' )
+        self.assertEqual(self.subs[6].text,'It has speaker changes >>>' )
+
+    def test_round_trip(self):
+        subs1  = utils.get_subs("basic.vtt")
+        parsed1 = subs1.to_internal()
+        srt_ouput = unicode(WEBVTTGenerator(parsed1))
+        subs2  = WEBVTTParser(srt_ouput, 'en')
+        parsed2 = subs2.to_internal()
+        self.assertEquals(len(subs1), len(subs2))
+
+        for x1, x2 in zip([x for x in parsed1.subtitle_items(WEBVTTGenerator.MAPPINGS)], \
+                [x for x in parsed2.subtitle_items(WEBVTTGenerator.MAPPINGS)]):
+            self.assertEquals(x1, x2)
+
+    def test_timed_data_parses_correctly(self):
+        subs = utils.get_data_file_path('timed_text.vtt')
+        parsed = babelsubs.load_from_file(subs, type='vtt', language='en')
+
+        self.assertNotEquals(parsed, None)
+
+        try:
+            webvtt = parsed.to('vtt')
+            self.assertNotEquals(webvtt, None)
+        except Exception, e:
+            self.fail(e)
+
+    def test_ampersand_escaping(self):
+        subs  = utils.get_subs("basic.vtt")
+        parsed = subs.to_internal()
+        sub_data = [x for x in parsed.subtitle_items(WEBVTTGenerator.MAPPINGS)]
+        self.assertEquals(sub_data[16].text, "such as MP4, theora, webM and <i>&</i> HTML 5.")
+
+    def test_invalid(self):
+        with self.assertRaises(SubtitleParserError):
+            WEBVTTParser ("this\n\nisnot a valid subs format","en")
+
+    def test_mixed_newlines(self):
+        # some folks will have valid srts, then edit them on an editor
+        # that will save line breaks on the current platform separator
+        # e.g. \n on unix , \r...
+        # make sure we normalize this stuff
+        subs = utils.get_subs("Untimed_text.vtt")
+        parsed = subs.to_internal()
+        self.assertEqual(len(subs), 43)
+        # second sub should have a line break
+        self.assertIn('<p begin="99:59:59.000" end="99:59:59.000">I\'m gutted. <br/>Absolutely gutted.</p>',
+            parsed.to_xml())
+
+
+class WEBVTTGeneratorTest(TestCase):
+
+    def setUp(self):
+        self.dfxp = utils.get_subs("with-formatting.dfxp").to_internal()
+        self.subs = self.dfxp.subtitle_items(mappings=WEBVTTGenerator.MAPPINGS)
+
+    def test_generated_formatting(self):
+        self.assertEqual(self.subs[2].text,'It has <b>bold</b> formatting' )
+        self.assertEqual(self.subs[3].text,'It has <i>italics</i> too' )
+        self.assertEqual(self.subs[4].text,'And why not <u>underline</u>' )
+        self.assertEqual(self.subs[5].text,'It has a html tag <a> should be in brackets' )
+        self.assertEqual(self.subs[6].text,'It has speaker changes >>>' )


### PR DESCRIPTION
Based on what I found inside the tree, I implemented: 
- WEBVTTGenerator
- WEBVTTParser
- Test cases for WEBVTT.

Thanks to the earlier contributors who made this task easier, with proper comments and great coding. Much of it is based on SRT, changing what is necessary to make it WebVTT compliant.
