### PR TITLE
GH-9 Fixing vtt parser and generator

### DIFF
--- a/babelsubs/generators/webvtt.py
+++ b/babelsubs/generators/webvtt.py
@@ -14,16 +14,13 @@ class WEBVTTGenerator(BaseGenerator):
 
     def __unicode__(self):
         output = ['WEBVTT\n']
-        i = 1
         for from_ms, to_ms, content, meta in self.subtitle_set.subtitle_items(mappings=self.MAPPINGS):
-            output.append(unicode(i))
             output.append(u'%s --> %s' % (
                 self.format_time(from_ms),
                 self.format_time(to_ms)
             ))
             output.append(content)
             output.append(u'')
-            i += 1
         return self.line_delimiter.join(output)[:-1]
 
     def format_time(self, milliseconds):

--- a/babelsubs/parsers/webvtt.py
+++ b/babelsubs/parsers/webvtt.py
@@ -10,8 +10,7 @@ class WEBVTTParser(BaseTextParser):
     _clean_pattern = re.compile(r'\{.*?\}', re.DOTALL)
 
     def __init__(self, input_string, language_code, eager_parse=True):
-        pattern = r'\d+\s*?\n'
-        pattern += r'(?P<s_hour>\d{2}):(?P<s_min>\d{2}):(?P<s_sec>\d{2})(.(?P<s_secfr>\d*))?'
+        pattern = r'(?P<s_hour>\d{2}):(?P<s_min>\d{2}):(?P<s_sec>\d{2})(.(?P<s_secfr>\d*))?'
         pattern += r' --> '
         pattern += r'(?P<e_hour>\d{2}):(?P<e_min>\d{2}):(?P<e_sec>\d{2})(.(?P<e_secfr>\d*))?'
         pattern += r'\n(\n|(?P<text>.+?)\n\n)'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,3 +69,4 @@ Supported formats
 * ttml
 * txt
 * json
+* vtt


### PR DESCRIPTION
Changes:

Generator no longer creates automatically numbered ID's for the cues.

Parser no longer tries to find an ID. This behavior needs to be fixed since .vtt has support for cues id. Will be opening a new issue for this.

Added vtt to supported formats
